### PR TITLE
Fix etherpad broken api_key authentication with update

### DIFF
--- a/api/docker-compose.yaml
+++ b/api/docker-compose.yaml
@@ -10,11 +10,13 @@ services:
       - MYSQL_USER=tlc
       - MYSQL_PASSWORD=tlc
   etherpad:
-    image: etherpad/etherpad
+    image: etherpad/etherpad:2.2.2
     ports:
       - "9001:9001"
+    environment:
+      AUTHENTICATION_METHOD: "apikey"
     volumes:
-      - ./APIKEY.txt:/opt/etherpad-lite/APIKEY.txt
+      - ./APIKEY.txt:/opt/etherpad-lite/APIKEY.txt:ro
   mail:
     image: bytemark/smtp
     restart: always

--- a/api/docker-compose.yaml
+++ b/api/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
       - MYSQL_USER=tlc
       - MYSQL_PASSWORD=tlc
   etherpad:
-    image: etherpad/etherpad:2.2.2
+    image: etherpad/etherpad
     ports:
       - "9001:9001"
     environment:

--- a/front/.gitignore
+++ b/front/.gitignore
@@ -13,7 +13,7 @@
 # profiling files
 chrome-profiler-events*.json
 speed-measure-plugin*.json
-
+.angular
 # IDEs and editors
 /.idea
 .project

--- a/front/angular.json
+++ b/front/angular.json
@@ -127,5 +127,8 @@
         }
       }
     }},
-  "defaultProject": "tlcfront"
+  "defaultProject": "tlcfront",
+  "cli": {
+    "analytics": false
+  }
 }


### PR DESCRIPTION
Etherpad 2.0.2 introduce a change in authentication method. They are moving from api_key to o-auth, api_key need now to be explicitly activated.

https://github.com/ether/etherpad-lite/issues/6350