### PR TITLE
fix(answer-poll): add pTemplate on option view buttons to render item text properly

### DIFF
--- a/front/src/app/answer-poll/answer-poll.component.html
+++ b/front/src/app/answer-poll/answer-poll.component.html
@@ -75,8 +75,8 @@
         </div>
 
         <div>
-          <p-selectButton  [options]="calendarortableoption" [(ngModel)]="calendarortable">
-            <ng-template let-item>
+          <p-selectButton [options]="calendarortableoption" [(ngModel)]="calendarortable">
+            <ng-template pTemplate="item" let-item>
               <i [class]="item.icon">Vue {{item.text}}</i>
             </ng-template>
           </p-selectButton>


### PR DESCRIPTION
Text displayed was [Object object].

<img width="1280" height="571" alt="Capture d’écran du 2025-12-17 10-54-58" src="https://github.com/user-attachments/assets/ef08bdd6-a596-4d68-aea9-c6f9d143af03" />
