### PR TITLE
Add Prometheus and Grafana observability stack for doodlestudent

### DIFF
--- a/api/OBSERVABILITY.md
+++ b/api/OBSERVABILITY.md
@@ -1,0 +1,128 @@
+# Mise en place de l'observabilite : Prometheus + Grafana
+
+## Objectif
+
+Ce document explique comment nous avons integre une stack d'observabilite dans le projet microservices `doodlestudent`.
+L'objectif est de superviser le service backend avec Prometheus et de visualiser les donnees de monitoring avec Grafana.
+
+## Perimetre
+
+Composants implementes :
+
+- Prometheus pour collecter les metriques
+- Grafana pour visualiser les metriques
+
+Fichiers modifies :
+
+- `api/docker-compose.yaml`
+- `api/prometheus.yml`
+
+## Prerequis
+
+- Docker et Docker Compose installes
+- Backend executable avec Quarkus (`./mvnw compile quarkus:dev`)
+
+## Etapes d'implementation
+
+### 1) Ajouter la configuration Prometheus
+
+Creer `api/prometheus.yml` :
+
+```yaml
+global:
+  scrape_interval: 5s
+
+scrape_configs:
+  - job_name: "quarkus-api"
+    metrics_path: /q/metrics
+    static_configs:
+      - targets: ["host.docker.internal:8080"]
+```
+
+Cette configuration interroge l'endpoint de metriques Quarkus toutes les 5 secondes.
+
+### 2) Ajouter les services Prometheus et Grafana
+
+Dans `api/docker-compose.yaml`, ajouter :
+
+- le service `prometheus` expose sur le port `9090`
+- le service `grafana` expose sur le port `3000`
+- le montage du fichier `prometheus.yml`
+
+### 3) Demarrer les services
+
+Depuis la racine du repository :
+
+```bash
+docker-compose -f "api/docker-compose.yaml" down
+docker-compose -f "api/docker-compose.yaml" up -d
+```
+
+Lancer le backend (terminal separe) :
+
+```bash
+cd api
+./mvnw compile quarkus:dev
+```
+
+Lancer le frontend si necessaire (terminal separe) :
+
+```bash
+cd front
+npm install
+npm start
+```
+
+## Validation
+
+### Sante des targets Prometheus
+
+- URL : `http://localhost:9090`
+- Verifier `Status > Targets`
+- Resultat attendu : la target `quarkus-api` est en etat `UP`
+
+### Source de donnees Grafana
+
+- URL : `http://localhost:3000`
+- Identifiants par defaut : `admin / admin`
+- Ajouter une datasource Prometheus avec l'URL : `http://prometheus:9090`
+- Resultat attendu : `Successfully queried the Prometheus API`
+
+### Verification d'une requete PromQL
+
+La requete ci-dessous renvoie des donnees valides :
+
+```promql
+up{job="quarkus-api"}
+```
+
+La valeur attendue est `1`, ce qui signifie que Prometheus arrive bien a collecter les metriques du backend.
+
+## Difficultes rencontrees et solutions (retour d'experience)
+
+### Difficulte 1 : certaines metriques JVM ne renvoyaient pas de donnees
+
+- Exemple : `base_cpu_system_load_average` renvoyait un resultat vide.
+- Cause : la disponibilite des metriques depend de l'environnement d'execution et du jeu de metriques exposees.
+- Solution : utiliser une metrique fiable pour valider l'integration :
+  - `up{job="quarkus-api"}`
+
+### Difficulte 2 : confusion sur le chemin d'execution de Docker Compose
+
+- Lancer Compose depuis le mauvais dossier ne trouvait pas le fichier de configuration.
+- Solution : executer Compose avec le chemin explicite depuis la racine du repository :
+  - `docker-compose -f "api/docker-compose.yaml" ...`
+
+## Resultat
+
+Nous avons integre avec succes une premiere stack d'observabilite dans un projet microservices :
+
+- Prometheus collecte les metriques du backend
+- Grafana est connecte a Prometheus
+- La chaine de monitoring est validee de bout en bout
+
+## Ameliorations possibles
+
+- Ajouter des dashboards Grafana preconfigures (provisioning JSON)
+- Ajouter des regles d'alerte dans Prometheus
+- Ajouter davantage de metriques applicatives et de labels

--- a/api/docker-compose.yaml
+++ b/api/docker-compose.yaml
@@ -22,3 +22,15 @@ services:
     restart: always
     ports:
       - "2525:25"
+  prometheus:
+    image: prom/prometheus:latest
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus

--- a/api/prometheus.yml
+++ b/api/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 5s
+
+scrape_configs:
+  - job_name: "quarkus-api"
+    metrics_path: /q/metrics
+    static_configs:
+      - targets: ["host.docker.internal:8080"]


### PR DESCRIPTION
Objectif

Cette PR ajoute une stack d’observabilité au projet microservices `doodlestudent` en utilisant Prometheus et Grafana.

L’objectif est de superviser la disponibilité du backend et de fournir une première couche de visualisation pour le suivi opérationnel.

 Ce qui a été implémenté

- Ajout du service Prometheus dans `api/docker-compose.yaml`
- Ajout du service Grafana dans `api/docker-compose.yaml`
- Ajout du fichier de configuration Prometheus `api/prometheus.yml`
- Ajout de la documentation d’installation et du retour d’expérience dans `api/OBSERVABILITY.md`

 Étapes de mise en place

1. Démarrage des dépendances du projet avec Docker Compose
2. Lancement du backend en mode développement Quarkus (`./mvnw compile quarkus:dev`)
3. Démarrage des conteneurs Prometheus et Grafana
4. Configuration de la datasource Grafana vers Prometheus (`http://prometheus:9090`)
5. Validation de la collecte de métriques et du comportement des requêtes

Validation effectuée

- La page de santé des targets Prometheus affiche `quarkus-api` en état `UP`
- Le test de datasource Grafana retourne : `Successfully queried the Prometheus API`
- Requête PromQL validée :
  - `up{job="quarkus-api"}` renvoie `1`

 Difficultés rencontrées et solutions

 1) Données absentes pour certaines métriques
- La requête `base_cpu_system_load_average` ne renvoyait pas de données dans cet environnement.
- Solution : utilisation de la métrique de connectivité fiable `up{job="quarkus-api"}` pour valider l’intégration de bout en bout.
- 

 2)Retour d’expérience

La mise en place est simple et efficace pour une première couche d’observabilité :
- rapide à intégrer
- facile à valider
- directement utile pour la supervision d’une architecture microservices
Les améliorations possibles incluent le provisionnement de dashboards Grafana et l’ajout de règles d’alerte.

Quelques captures d'écran : 
<img width="1189" height="671" alt="Capture d’écran 2026-04-29 à 14 14 28" src="https://github.com/user-attachments/assets/b688641a-e452-4569-b661-75cb190e2c57" />
<img width="1189" height="671" alt="Capture d’écran 2026-04-29 à 14 15 28" src="https://github.com/user-attachments/assets/bf144c50-a36d-4c04-ae84-16d2b9ed3744" />
